### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-gulp.yml
+++ b/.github/workflows/npm-gulp.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/stvn101/Lunasworld/security/code-scanning/5](https://github.com/stvn101/Lunasworld/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will explicitly set `contents: read`, which is sufficient for the current workflow since it only checks out the repository and installs dependencies. This change ensures that the workflow does not inherit unnecessary permissions from the repository or organization.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
