### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -18,6 +18,10 @@
 
 name: "Microsoft Defender For Devops"
 
+permissions:
+  contents: read
+  security-events: write
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/stvn101/Lunasworld/security/code-scanning/8](https://github.com/stvn101/Lunasworld/security/code-scanning/8)

To fix the issue, add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the actions used in the workflow, the following permissions are appropriate:
- `contents: read` for accessing repository contents.
- `security-events: write` for uploading SARIF files to the Security tab.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`MSDO`) to limit its scope.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
